### PR TITLE
Set puncher to the user for grenades/rockets.

### DIFF
--- a/shooter.lua
+++ b/shooter.lua
@@ -393,7 +393,7 @@ function shooter:blast(pos, radius, fleshy, distance, user)
 				obj_pos.y = obj_pos.y + 1.7
 				blast_pos = {x=pos.x, y=pos.y + 4, z=pos.z}
 				if minetest.line_of_sight(obj_pos, blast_pos, 1) then
-					obj:punch(obj, 1.0, {
+					obj:punch(user, 1.0, {
 						full_punch_interval = 1.0,
 						damage_groups = {fleshy=damage},
 					})


### PR DESCRIPTION
Previously, on_punch() indicated that victims of grenades and rocket launcher attacks were punching themselves. This is causing problems with my justice mod which tries to determine who is responsible for violence.