### PR TITLE
Reduce effective range of shotgun

### DIFF
--- a/shooter_guns/init.lua
+++ b/shooter_guns/init.lua
@@ -60,7 +60,7 @@ shooter.register_weapon("shooter_guns:shotgun", {
 	inventory_image = "shooter_shotgun.png",
 	spec = {
 		rounds = 50,
-		range = 60,
+		range = 30,
 		step = 15,
 		tool_caps = {full_punch_interval=1.5, damage_groups={fleshy=4}},
 		groups = {cracky=3, snappy=2, crumbly=2, choppy=2, fleshy=1, oddly_breakable_by_hand=1},


### PR DESCRIPTION
Simple change that halves the range of the shotgun for improved realism. Players abuse the unrealistic range of the shotgun to use it as a sniper rifle. While `0.6.0-dev` limits the range to 60, I feel that still too high.