### PR TITLE
Increase clip size of SMG to 32

### DIFF
--- a/shooter_guns/init.lua
+++ b/shooter_guns/init.lua
@@ -87,7 +87,7 @@ shooter.register_weapon("shooter_guns:machine_gun", {
 	inventory_image = "shooter_smgun.png",
 	spec = {
 		automatic = true,
-		rounds = 20,
+		rounds = 32,
 		range = 160,
 		step = 20,
 		tool_caps = {full_punch_interval=0.1, damage_groups={fleshy=2}},


### PR DESCRIPTION
The SMG, which bears a striking resemblance to the [Micro Uzi](http://www.israeli-weapons.com/weapons/small_arms/uzi/Uzi-Micro.html) has too small a magazine, considering it's full-auto now. I propose increasing its capacity to 32 rounds (which still matches the clip size of the Micro Uzi).