### PR TITLE
Use table.copy instead of using = syntax

### DIFF
--- a/shooter/api.lua
+++ b/shooter/api.lua
@@ -56,9 +56,9 @@ shooter.default_particles = {
 
 local shots = {}
 local shooting = {}
-local config = shooter.config
+local config = table.copy(shooter.config)
 local server_step = minetest.settings:get("dedicated_server_step")
-local v3d = vector
+local v3d = table.copy(vector)
 local PI = math.pi
 local sin = math.sin
 local cos = math.cos


### PR DESCRIPTION
Using table.copy ensures that a new copy of the table is created. See https://github.com/stujones11/shooter/commit/88750a0353d604b745dfa26fbf7da0b7da1d8d43#commitcomment-33037187

