### PR TITLE
Allow other mods to change wear of registered guns

### DIFF
--- a/shooter/api.lua
+++ b/shooter/api.lua
@@ -96,7 +96,7 @@ shooter.register_weapon = function(name, def)
 				local spec = shooter.get_weapon_spec(nil, name) or
 					table.copy(def.spec)
 				if shooter.fire_weapon(user, itemstack, spec) then
-					itemstack:add_wear(def.spec.wear)
+					itemstack:add_wear(spec.wear)
 					if itemstack:get_count() == 0 then
 						itemstack:replace(def.unloaded_item.name)
 					end


### PR DESCRIPTION
I have a PvP game I'm doing and I'm changing some gun settings from a mod so I don't(?) have to mess with licensing.

This code should allow mods to use `shooter.registered_weapons` to change `def.spec.wear` which will in turn allow them to change how many rounds a weapon has.

I have tested this and found no problems